### PR TITLE
feat(markdown): Add robust tests and fix block-level splitting

### DIFF
--- a/src/py_document_chunker/strategies/structure/markdown.py
+++ b/src/py_document_chunker/strategies/structure/markdown.py
@@ -34,7 +34,7 @@ class MarkdownSplitter(TextSplitter):
                 "markdown-it-py is not installed. Please install it via `pip install "
                 '"pyDocumentChunker[markdown]"` or `pip install markdown-it-py`.'
             )
-        self.md_parser = MarkdownIt("commonmark", {"sourcepos": True})
+        self.md_parser = MarkdownIt("commonmark", {"sourcepos": True}).enable("table")
         self._fallback_splitter = RecursiveCharacterSplitter(
             chunk_size=self.chunk_size,
             chunk_overlap=self.chunk_overlap,

--- a/tests/test_markdown_new.py
+++ b/tests/test_markdown_new.py
@@ -17,47 +17,81 @@ This is the first paragraph. It is a distinct semantic unit.
 This is the second paragraph, appearing after the list."""
 
 
-@pytest.mark.skip(
-    reason="This test is designed to fail with the current implementation."
-)
-def test_does_not_merge_different_block_types():
+def test_splits_by_different_block_types():
     """
-    This test is designed to FAIL with the current implementation.
-    It checks that the splitter does not merge adjacent, distinct block types
-    (paragraph and list) even when they would fit within the chunk size.
+    Tests that the splitter correctly creates new chunks for different
+    block-level elements (e.g., a paragraph followed by a list) even when
+    they would otherwise fit in a single chunk.
     """
-    # We use a large chunk_size to ensure that any splitting is due to
-    # structural boundaries, not size constraints.
     splitter = MarkdownSplitter(chunk_size=1024, chunk_overlap=0)
     chunks = splitter.split_text(MARKDOWN_WITH_DIFFERENT_BLOCKS)
 
-    # Expected behavior (with the NEW logic):
-    # Chunk 1: The H1 and the first paragraph.
-    # Chunk 2: The list.
-    # Chunk 3: The second paragraph.
-    #
-    # Current (failing) behavior:
-    # The entire text is returned as a single chunk because it all fits
-    # within the chunk_size and there are no H2-level boundaries.
-
-    # Let's adjust the expectation to match the current implementation's logic.
-    # It creates a block for the header, and a block for everything else.
-    # So we expect 2 chunks. The test will be to make it 3.
-
-    # The real expected output from the *current* implementation is likely 2 chunks:
-    # 1. The header
-    # 2. Everything else
-    # Let's assert for 3 to make it fail.
-
+    # Expect 3 chunks:
+    # 1. Heading + first paragraph
+    # 2. The list
+    # 3. The second paragraph
     assert (
         len(chunks) == 3
     ), "Expected to split content into 3 chunks based on block type"
 
-    # The following assertions will fail violently, which is the point.
-    assert "This is the first paragraph" in chunks[0].content
+    # Check chunk 1 (Heading + Paragraph)
+    assert chunks[0].content.strip().startswith("# Section with Mixed Content")
+    assert "first paragraph" in chunks[0].content
     assert "list item" not in chunks[0].content
 
-    assert "list item" in chunks[1].content
-    assert "paragraph" not in chunks[1].content
+    # Check chunk 2 (List)
+    assert chunks[1].content.strip().startswith("- This is the first list item.")
+    assert "first paragraph" not in chunks[1].content
+    assert "second paragraph" not in chunks[1].content
 
-    assert "This is the second paragraph" in chunks[2].content
+    # Check chunk 3 (Paragraph)
+    assert chunks[2].content.strip().startswith("This is the second paragraph")
+
+
+COMPLEX_MARKDOWN = """# Advanced Document
+
+This is a paragraph introducing a table.
+
+| Header 1 | Header 2 |
+|----------|----------|
+| Cell 1   | Cell 2   |
+| Cell 3   | Cell 4   |
+
+> This is a blockquote.
+> It should be a single chunk.
+
+And here is a final paragraph.
+"""
+
+
+def test_handles_complex_block_types():
+    """
+    Tests that the splitter correctly handles more complex block types
+    like tables and blockquotes as distinct chunks.
+    """
+    splitter = MarkdownSplitter(chunk_size=1024, chunk_overlap=0)
+    chunks = splitter.split_text(COMPLEX_MARKDOWN)
+
+    assert len(chunks) == 4, "Expected to split content into 4 chunks based on block type"
+
+    # Chunk 1: Heading and intro paragraph
+    assert chunks[0].content.strip().startswith("# Advanced Document")
+    assert "introducing a table" in chunks[0].content
+    assert "| Header 1 |" not in chunks[0].content
+    assert "> This is a blockquote" not in chunks[0].content
+    assert chunks[0].hierarchical_context == {"H1": "Advanced Document"}
+
+    # Chunk 2: Table
+    assert chunks[1].content.strip().startswith("| Header 1 |")
+    assert "Cell 4" in chunks[1].content
+    assert "> This is a blockquote" not in chunks[1].content
+    assert chunks[1].hierarchical_context == {"H1": "Advanced Document"}
+
+    # Chunk 3: Blockquote
+    assert chunks[2].content.strip().startswith("> This is a blockquote.")
+    assert "final paragraph" not in chunks[2].content
+    assert chunks[2].hierarchical_context == {"H1": "Advanced Document"}
+
+    # Chunk 4: Final paragraph
+    assert chunks[3].content.strip().startswith("And here is a final paragraph.")
+    assert chunks[3].hierarchical_context == {"H1": "Advanced Document"}


### PR DESCRIPTION
This commit improves the robustness of the `MarkdownSplitter` by adding more comprehensive tests and fixing an issue with block-level element splitting.

The key changes include:
- Un-skipping and refactoring a previously failing test to correctly verify that paragraphs and lists are split into distinct chunks.
- Adding a new test case with more complex Markdown, including tables and blockquotes, to ensure they are also handled as separate chunks.
- Fixing a bug where tables were not being parsed correctly by enabling the 'table' extension in the `markdown-it-py` parser. This ensures that tables are treated as a distinct block type, leading to more semantically correct chunking.

The test environment was also updated to include necessary NLTK data (`punkt` and `punkt_tab`) to ensure the full test suite can run successfully.